### PR TITLE
Fix double-escaped entities in title, improve thumbnail URL sanitisation

### DIFF
--- a/block_rss_plus.php
+++ b/block_rss_plus.php
@@ -247,14 +247,15 @@
 			
 	if ($enclosure = $item->get_enclosure())
 	{
-	foreach ((array) $enclosure->get_thumbnail(0) as $thumbnail)
-		$r .= html_writer::link( clean_param($link, PARAM_URL), '<img src="'.$thumbnail.'"/>', array() );
-		//$r.='<img src="'.$thumbnail.'"/>'."\n";
-	
+		foreach ((array) $enclosure->get_thumbnail(0) as $thumbnail) {
+			$r .= html_writer::link( clean_param($link, PARAM_URL), 
+				html_writer::empty_tag('img', array(
+					'src' => clean_param($thumbnail, PARAM_URL)
+				)), array());
+		}
 	} 
 		
-	
-                $r.= html_writer::end_tag('div');
+	$r.= html_writer::end_tag('div');
             
         $r.= html_writer::end_tag('li');
 

--- a/block_rss_plus.php
+++ b/block_rss_plus.php
@@ -192,9 +192,9 @@
     
 	function get_item_html($item){
 
-        $link        = $item->get_link();
-        $title       = $item->get_title();
-        $description = $item->get_description();
+        $link        = $item->get_link(); // we will unescape this below using \moodle_url
+        $title       = htmlspecialchars_decode($item->get_title());
+        $description = htmlspecialchars_decode($item->get_description());
 
 
         if(empty($title)){

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2016082200;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2018022100;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2010112400;        // Requires this Moodle version
 $plugin->component = 'block_rss_plus';  // Full name of the plugin (used for diagnostics)
 $plugin->cron      = 300;               // Set min time between cron executions to 300 secs (5 mins)
 $plugin->maturity = MATURITY_ALPHA;
-$plugin->release = '2.x (Build: 2016082200)';
+$plugin->release = '2.x (Build: 2018022100)';


### PR DESCRIPTION
These commits address an issue with double-escaped entities such as &, < (htmlspecialchars) in the title and/or description of the feed.
These would appear to the user as, for example:


> Fish &amp;amp; Chips

The data fetched from Moodle SimplePie, which are already encoded, are encoded again when the title or description are displayed with the call to Moodle's `s()` function. The commit removes the initial encoding from the SimplePie data so that the entities are only encoded once -- at display time.

It also changes the output of the thumbnail `img` tag to sanitise the URL parameter of the tag using `clean_param()`.